### PR TITLE
fix: categories filter must leave other filters intact

### DIFF
--- a/controller/filters/filter_by_categories.js
+++ b/controller/filters/filter_by_categories.js
@@ -1,0 +1,37 @@
+function filterByCategories(req, renderedQuery) {
+  if (!req || !req.query) {
+      return;
+  }
+
+  if (!renderedQuery || !renderedQuery.body || !renderedQuery.body.query || !renderedQuery.body.query.bool) {
+      return;
+  }
+
+  if (!renderedQuery.body.query.bool.filter) {
+    renderedQuery.body.query.bool.filter = [];
+  }
+
+  // Entur:
+  // Using req.query.categories bypasses the sanitizer function and
+  // leaves intact the original categories filter from pelias-query package,
+  // e.g.: query.filter( peliasQuery.view.categories );
+  // in query/reverse.js#L24
+  //
+  // Instead we splice out categories from the rendered query and use that to add a
+  // new filter, wich uses our own field.
+  var index = renderedQuery.body.query.bool.filter.findIndex(f => f.terms && f.terms.category);
+  var match = index !== -1 && renderedQuery.body.query.bool.filter.splice(index, 1).shift();
+  var categories = match ? match.terms.category : [];
+
+  if (categories.length > 0 && !categories.includes('no_filter')) {
+      var categoriesTerms = {
+          terms: {
+              'category_filter': categories
+          }
+      };
+
+      renderedQuery.body.query.bool.filter.push(categoriesTerms);
+  }
+}
+
+module.exports = filterByCategories;

--- a/controller/filters/filter_by_parent_ids.js
+++ b/controller/filters/filter_by_parent_ids.js
@@ -1,0 +1,35 @@
+function filterByParentIds(req, renderedQuery) {
+  if (!req || !req.query) {
+      return;
+  }
+  if (!renderedQuery || !renderedQuery.body || !renderedQuery.body.query || !renderedQuery.body.query.bool) {
+      return;
+  }
+  var countyIds = req.query['boundary.county_ids'];
+  var localityIds = req.query['boundary.locality_ids'];
+  if (countyIds || localityIds) {
+      if (!renderedQuery.body.query.bool.filter) {
+          renderedQuery.body.query.bool.filter = [];
+      }
+
+      if (countyIds) {
+          var countyTerms = {
+              terms: {
+                  'parent.county_id': countyIds.split(',')
+              }
+          };
+          renderedQuery.body.query.bool.filter.push(countyTerms);
+      }
+
+      if (localityIds) {
+          var localityTerms = {
+              terms: {
+                  'parent.locality_id': localityIds.split(',')
+              }
+          };
+          renderedQuery.body.query.bool.filter.push(localityTerms);
+      }
+  }
+}
+
+module.exports = filterByParentIds

--- a/controller/filters/filter_by_tariff_zones.js
+++ b/controller/filters/filter_by_tariff_zones.js
@@ -1,0 +1,35 @@
+function filterByTariffZones(req, renderedQuery) {
+  if (!req || !req.query) {
+      return;
+  }
+  if (!renderedQuery || !renderedQuery.body || !renderedQuery.body.query || !renderedQuery.body.query.bool) {
+      return;
+  }
+  var tariffZoneIds = req.query.tariff_zone_ids;
+  var tariffZoneAuthorities = req.query.tariff_zone_authorities;
+  if (tariffZoneIds || tariffZoneAuthorities) {
+      if (!renderedQuery.body.query.bool.filter) {
+          renderedQuery.body.query.bool.filter = [];
+      }
+
+      if (tariffZoneIds) {
+          var tariffZoneIdsTerms = {
+              terms: {
+                  'tariff_zones': tariffZoneIds.split(',')
+              }
+          };
+          renderedQuery.body.query.bool.filter.push(tariffZoneIdsTerms);
+      }
+
+      if (tariffZoneAuthorities) {
+          var tariffZoneAuthoritiesTerms = {
+              terms: {
+                  'tariff_zone_authorities': tariffZoneAuthorities.split(',')
+              }
+          };
+          renderedQuery.body.query.bool.filter.push(tariffZoneAuthoritiesTerms);
+      }
+  }
+}
+
+module.exports = filterByTariffZones;

--- a/test/unit/controller/filters/filter_by_categories.js
+++ b/test/unit/controller/filters/filter_by_categories.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const _ = require('lodash');
+const filter_by_categories = require('../../../../controller/filters/filter_by_categories');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = (test, common) => {
+  test('valid interface', (t) => {
+    t.equal(typeof filter_by_categories, 'function', 'filter_by_categories is a function');
+    t.end();
+  });
+};
+
+module.exports.tests.true_conditions = (test, common) => {
+  test('successfully moves categories from category to category_filter', (t) => {
+    const testSubject = {
+      body: {
+        query: {
+          bool: {
+            filter: [
+              {
+                terms: {
+                  category: ['foo']
+                }
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    filter_by_categories({ query: {}}, testSubject);
+    
+
+    t.deepEqual(testSubject.body.query.bool.filter, [
+      {
+        terms: {
+          category_filter: ['foo']
+        }
+      }
+      ], 'category_filter was added to the filter array and category was removed');
+
+    t.end();
+
+  });
+}
+
+module.exports.tests.true_conditions = (test, common) => {
+  test('leaves other filters intact', (t) => {
+    const testSubject = {
+      body: {
+        query: {
+          bool: {
+            filter: [
+              {
+                terms: {
+                  category: ['foo'],
+                }
+              },
+              {
+                terms: {
+                  bar: ['baz']
+                }
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    filter_by_categories({ query: {}}, testSubject);
+    
+
+    t.deepEqual(testSubject.body.query.bool.filter, [
+      {
+        terms: {
+          bar: ['baz']
+        }
+      },
+      {
+        terms: {
+          category_filter: ['foo'],
+        }
+      }
+      ], 'category_filter was added to the filter array and category was removed');
+
+    t.end();
+
+  });
+}
+
+module.exports.all = (tape, common) => {
+  function test(name, testFunction) {
+    return tape(`GET /filter_by_categories ${name}`, testFunction);
+  }
+
+  for( const testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -29,6 +29,7 @@ var tests = [
   require('./controller/predicates/is_coarse_reverse'),
   require('./controller/predicates/is_only_non_admin_layers'),
   require('./controller/predicates/is_request_sources_only_whosonfirst'),
+  require('./controller/filters/filter_by_categories'),
   require('./helper/debug'),
   require('./helper/diffPlaces'),
   require('./helper/geojsonify_place_details'),


### PR DESCRIPTION
When the categories spliced the filter array, the "deleteCount" argument was missing, so it deleted the remainder of the array, instead of just the matching "categories" filter, which is added back with a different term.

This fixes so that it only deletes 1 element from the array and other filters are left intact